### PR TITLE
Ability to toggle full path names from the Signals view

### DIFF
--- a/src/components/Debugger/Signals/List/index.js
+++ b/src/components/Debugger/Signals/List/index.js
@@ -14,6 +14,7 @@ export default connect({
   isExecuting: state`debugger.isExecuting`,
   executedBySignals: state`debugger.executedBySignals`,
   searchValue: state`debugger.searchValue`,
+  showFullPathNames: state`debugger.showFullPathNames`,
   signalClicked: signal`debugger.signalClicked`
 },
   class SignalsList extends Component {
@@ -80,18 +81,7 @@ export default connect({
         }, false)
       )
 
-      const className = classnames({
-        'list-item': true,
-        'list-activeItem': isActive,
-        'list-grouped': signal.isGrouped,
-        'list-item-error': hasError,
-        pulse: isExecuting
-      })
-      const indicatorClassname = classnames('list-indicator', {
-        'list-fadedItem': hasSearchContent === false
-      })
       const isInOpenGroup = this.props.debugger.expandedSignalGroups.indexOf(signal.groupId) !== -1
-
       if (
         prevSignal &&
         prevSignal.groupId === signal.groupId &&
@@ -99,7 +89,6 @@ export default connect({
       ) {
         return null
       }
-
       let groupCount = 1
       for (let x = index + 1; x < this.props.signalsList.length - 1; x++) {
         if (this.props.signalsList[x].groupId === signal.groupId) {
@@ -108,15 +97,32 @@ export default connect({
           break
         }
       }
+      const isGrouped = (!prevSignal || prevSignal.groupId !== signal.groupId) && groupCount > 1
+
+      const className = classnames({
+        'list-item': true,
+        'list-activeItem': isActive,
+        'list-grouped': signal.isGrouped,
+        'list-item-error': hasError,
+        'list-item-grouped': isGrouped,
+        pulse: isExecuting
+      })
+
+      const indicatorClassname = classnames('list-indicator', {
+        'list-fadedItem': hasSearchContent === false
+      })
 
       return (
         <li
           onClick={(event) => this.onSignalClick(event, signal, index)}
           className={className}
-          key={index}>
-          {isInOpenGroup && prevSignal && prevSignal.groupId === signal.groupId ? null : <div className={indicatorClassname} style={signalStyle} />}
+          key={index}
+        >
+          {isInOpenGroup && prevSignal && prevSignal.groupId === signal.groupId ? null : <div className={indicatorClassname} style={signalStyle}/>}
+          <div className='list-groupCount'>{isGrouped ? ` (${groupCount})` : null}</div>
           <span className='list-name'>
-            {name} <small>{(!prevSignal || prevSignal.groupId !== signal.groupId) && groupCount > 1 ? ` (${groupCount})` : null}</small> {this.props.type === 'cft' && signal.source === 'ft' ? <small className='ft-indication'>FT</small> : null}
+            {this.props.showFullPathNames ? signal.name : name}
+            {this.props.type === 'cft' && signal.source === 'ft' ? <small className='ft-indication'>FT</small> : null}
           </span>
         </li>
       )

--- a/src/components/Debugger/Signals/List/styles.css
+++ b/src/components/Debugger/Signals/List/styles.css
@@ -7,7 +7,7 @@
   border: 1px solid #DDD;
   width: 100%;
   list-style-type: none;
-  height: calc(100vh - 156px);
+  height: calc(100vh - 181px);
   overflow-y: scroll;
 }
 
@@ -20,6 +20,9 @@
   border-bottom: 1px solid #DDD;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+.signals .list-item-grouped {
+  padding-right: 25px;
 }
 
 .signals .list-item:hover {
@@ -42,10 +45,6 @@
   border-left: 5px solid #DDD;
 }
 
-.signals .list-grouped {
-
-}
-
 .signals .list-indicator {
   position: absolute;
   left: 0;
@@ -56,9 +55,17 @@
 }
 
 .signals .list-name {
+  font-size: 0.9rem;
   user-select: none;
   -webkit-touch-callout: none;
   -webkit-user-select: none;
+}
+
+.signals .list-groupCount {
+  position: absolute;
+  right: 4px;
+  top: -1px;
+  font-size: 0.7rem;
 }
 
 .signals .list-type {

--- a/src/components/Debugger/Signals/index.js
+++ b/src/components/Debugger/Signals/index.js
@@ -16,7 +16,8 @@ export default connect({
   useragent: state`useragent`,
   currentSignalExecutionId: state`debugger.currentSignalExecutionId`,
   isExecuting: state`debugger.isExecuting`,
-  resetClicked: signal`debugger.resetClicked`
+  resetClicked: signal`debugger.resetClicked`,
+  toggleFullPathNamesClicked: signal`debugger.toggleFullPathNamesClicked`
 },
   class Signals extends Component {
     constructor (props) {
@@ -42,6 +43,10 @@ export default connect({
         this.textarea.select()
       })
     }
+    onToggleFullPathNamesClick () {
+      this.props.toggleFullPathNamesClicked()
+      connector.sendEvent(this.props.port, 'toggleFullPathNames')
+    }
     render () {
       const currentSignalExecutionId = this.props.currentSignalExecutionId
 
@@ -49,6 +54,12 @@ export default connect({
         <div className='signals'>
           <div className='signals-list'>
             <List />
+            <button
+              onClick={() => this.onToggleFullPathNamesClick()}
+              className='signals-toggleFullPathNames'
+              disabled={!currentSignalExecutionId}>
+              Toggle Full Path Names
+            </button>
             <button
               onClick={() => this.onCopySignalsClick()}
               className='signals-rewrite'

--- a/src/components/Debugger/Signals/index.js
+++ b/src/components/Debugger/Signals/index.js
@@ -45,7 +45,6 @@ export default connect({
     }
     onToggleFullPathNamesClick () {
       this.props.toggleFullPathNamesClicked()
-      connector.sendEvent(this.props.port, 'toggleFullPathNames')
     }
     render () {
       const currentSignalExecutionId = this.props.currentSignalExecutionId

--- a/src/components/Debugger/Signals/styles.css
+++ b/src/components/Debugger/Signals/styles.css
@@ -10,13 +10,7 @@
   min-width: 200px;
 }
 
-.signals-signal {
-  margin-left: 10px;
-  flex: 3;
-  overflow: auto;
-}
-
-.signals-rewrite {
+.signals-list button {
   display: block;
   border-top: 0;
   border-left: 1px solid #DDD;
@@ -30,29 +24,21 @@
   cursor: pointer;
   font-weight: bold;
 }
-.signals-rewrite:hover {
+
+.signals-list button:hover {
   background-color: #FAFAFA;
 }
 
 .signals-reset {
-  display: block;
-  border-top: 0;
-  border-left: 1px solid #DDD;
-  border-right: 1px solid #DDD;
-  border-bottom: 1px solid #DDD;
-  background-color: #fff;
   border-bottom-left-radius: 3px;
   border-bottom-right-radius: 3px;
-  height: 25px;
-  padding: 5px;
-  margin: 0;
-  width: 100%;
-  cursor: pointer;
   margin-bottom: 5px;
-  font-weight: bold;
 }
-.signals-reset:hover {
-  background-color: #FAFAFA;
+
+.signals-signal {
+  margin-left: 10px;
+  flex: 3;
+  overflow: auto;
 }
 
 .signals-textarea {

--- a/src/modules/Debugger/index.js
+++ b/src/modules/Debugger/index.js
@@ -10,6 +10,7 @@ import searchValueChanged from './signals/searchValueChanged'
 import escPressed from './signals/escPressed'
 import addPortErrored from './signals/addPortErrored'
 import pathClicked from './signals/pathClicked'
+import toggleFullPathNamesClicked from './signals/toggleFullPathNamesClicked'
 
 export default () => ({
   state: {
@@ -30,7 +31,8 @@ export default () => ({
     renders: [],
     mutationsError: false,
     searchValue: '',
-    expandedPaths: []
+    expandedPaths: [],
+    showFullPathNames: false
   },
   signals: {
     pageChanged,
@@ -44,6 +46,7 @@ export default () => ({
     resetClicked,
     modelClicked,
     addPortErrored,
-    pathClicked
+    pathClicked,
+    toggleFullPathNamesClicked,
   }
 })

--- a/src/modules/Debugger/index.js
+++ b/src/modules/Debugger/index.js
@@ -47,6 +47,6 @@ export default () => ({
     modelClicked,
     addPortErrored,
     pathClicked,
-    toggleFullPathNamesClicked,
+    toggleFullPathNamesClicked
   }
 })

--- a/src/modules/Debugger/signals/toggleFullPathNamesClicked.js
+++ b/src/modules/Debugger/signals/toggleFullPathNamesClicked.js
@@ -1,0 +1,6 @@
+import {set, toggle} from 'cerebral/operators'
+import {state} from 'cerebral/tags'
+
+export default [
+  toggle(state`debugger.showFullPathNames`)
+]


### PR DESCRIPTION
- Added toggle button to Signals view
- All Signals list action buttons now share similar styles
- Slightly reduced font size of Signal list text
- Fixed signal count so it is always visible,
- Added a class to fix text-overflow issues with new signal count styles
- Fixes #18 