### PR TITLE
Color named sequences in signals view

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "cerebral": "^4.0.1",
     "classnames": "^2.2.5",
     "color": "^0.11.4",
+    "color-hash": "^1.0.3",
     "electron-default-menu": "^1.0.0",
     "electron-json-storage": "^4.0.2",
     "electron-log": "^2.2.2",

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -1,104 +1,11 @@
-import Color from 'color'
+import ColorHash from 'color-hash'
 
-export function hashCode (str) { // java String#hashCode
-  var hash = 0
-  for (var i = 0; i < str.length; i++) {
-    hash = str.charCodeAt(i) + ((hash << 5) - hash)
+export function nameToColors (moduleName, signalName, lightness = 0.5, saturation = 0.5) {
+  let colorHash = new ColorHash({saturation: saturation, lightness: lightness})
+  return {
+    backgroundColor: colorHash.hex(moduleName + signalName),
+    color: '#fff'
   }
-  return hash
-}
-
-export function intToRGB (i) {
-  var c = (i & 0x00FFFFFF)
-        .toString(16)
-        .toUpperCase()
-
-  return '00000'.substring(0, 6 - c.length) + c
-}
-
-export function hexToRgb (hex) {
-  var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
-  return result ? {
-    r: parseInt(result[1], 16),
-    g: parseInt(result[2], 16),
-    b: parseInt(result[3], 16)
-  } : null
-}
-
-export function checkLuminance (c) {
-  c = c.substring(1)      // strip #
-  var rgb = parseInt(c, 16)   // convert rrggbb to decimal
-  var r = (rgb >> 16) & 0xff  // extract red
-  var g = (rgb >> 8) & 0xff  // extract green
-  var b = (rgb >> 0) & 0xff  // extract blue
-
-  return 0.2126 * r + 0.7152 * g + 0.0722 * b // per ITU-R BT.709
-}
-
-export function ColorLuminance (hex, lum) {
-  // validate hex string
-  hex = String(hex).replace(/[^0-9a-f]/gi, '')
-  if (hex.length < 6) {
-    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2]
-  }
-  lum = lum || 0
-
-  // convert to decimal and change luminosity
-  var rgb = '#'
-  var c
-  var i
-  for (i = 0; i < 3; i++) {
-    c = parseInt(hex.substr(i * 2, 2), 16)
-    c = Math.round(Math.min(Math.max(0, c + (c * lum)), 255)).toString(16)
-    rgb += ('00' + c).substr(c.length)
-  }
-
-  return rgb
-}
-
-const FNV1_32A_INIT = 0x811c9dc5
-function fnv32aHash (str) {
-  let hval = FNV1_32A_INIT
-  for (var i = 0; i < str.length; ++i) {
-    hval ^= str.charCodeAt(i)
-    hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24)
-  }
-  return hval >>> 0
-}
-
-export function nameToColors (moduleName, signalName, maxDarken = -0.4, maxLighten = 0.8) {
-  const colors = [
-    '#E91E63', // Pink
-    '#9C27B0', // Purple
-    '#673AB7', // Deep Purple
-    '#3F51B5', // Indigo
-    '#2196F3', // Blue
-    '#03A9F4', // Light Blue
-    '#00BCD4', // Cyan
-    '#009688', // Teal
-    '#4CAF50', // Green
-    '#8BC34A', // Light Green
-    '#CDDC39', // Lime
-    '#FFEB3B', // Yellow
-    '#FFC107', // Amber
-    '#FF9800', // Orange
-    '#FF5722', // Deep Orange
-    '#795548', // Brown
-    '#607D8B' // Blue Grey
-  ]
-
-  const hashedModuleName = Math.abs(fnv32aHash(moduleName))
-  const baseColorIndex = hashedModuleName % colors.length
-  const baseColor = Color(colors[baseColorIndex])
-
-  const hashedSignalName = Math.abs(fnv32aHash(signalName))
-  const lightenByNormalized = hashedSignalName / Math.pow(2, 32)
-  const interpolatedLighten = maxDarken + lightenByNormalized * (maxLighten - maxDarken)
-  const interpolatedColor = baseColor.lighten(interpolatedLighten)
-  const backgroundColor = interpolatedColor.hexString()
-
-  const color = interpolatedColor.dark() ? 'white' : 'black'
-  return {backgroundColor, color}
 }
 
 export function isObject (obj) {

--- a/src/components/Debugger/Signals/Signal/Path/styles.css
+++ b/src/components/Debugger/Signals/Signal/Path/styles.css
@@ -1,5 +1,5 @@
 .action-path {
-  background-color: #333;
+  background-color: #6A6A6A;
   min-height: 25px;
   margin-bottom: 1px;
   font-size: 14px;

--- a/src/components/Debugger/Signals/Signal/Sequence/index.js
+++ b/src/components/Debugger/Signals/Signal/Sequence/index.js
@@ -1,6 +1,7 @@
 import './styles.css'
 import Inferno from 'inferno' // eslint-disable-line
 import Component from 'inferno-component' // eslint-disable-line
+import { nameToColors } from '../../../../../common/utils'
 
 function debounce (func, wait, immediate) {
   var timeout
@@ -22,8 +23,17 @@ class Sequence extends Component {
   constructor (props) {
     super(props)
     this.toggleStickyName = this.toggleStickyName.bind(this)
-    this.state = { containerStyle: null, nameStyle: null }
     this.signalLeft = 0
+    this.baseContainerStyle = {
+      flexBasis: '20px'
+    }
+    this.baseNameStyle = {}
+    if (this.props.sequence.name) {
+      this.baseContainerStyle.flexBasis = '30px'
+      this.baseContainerStyle.backgroundColor = nameToColors(this.props.sequence.name, this.props.sequence.name, 0.9, 0.2).backgroundColor
+      this.baseContainerStyle.color = nameToColors(this.props.sequence.name, this.props.sequence.name).backgroundColor
+    }
+    this.state = { containerStyle: this.baseContainerStyle, nameStyle: this.baseNameStyle }
   }
   componentDidMount () {
     const signalEl = document.querySelector('#signal')
@@ -54,19 +64,19 @@ class Sequence extends Component {
 
     let change = {
       type: 'default',
-      containerStyle: null,
-      nameStyle: null
+      containerStyle: Object.assign({}, this.baseContainerStyle),
+      nameStyle: Object.assign({}, this.baseNameStyle)
     }
 
     if (nameBounds.top < signalEl.scrollTop) {
       change = {
         type: 'initialMoving',
-        containerStyle: null,
-        nameStyle: {
+        containerStyle: Object.assign({}, this.baseContainerStyle),
+        nameStyle: Object.assign({}, this.baseNameStyle, {
           position: 'fixed',
           left: (nameBounds.left + this.signalLeft) + 'px',
           top: '122px'
-        },
+        }),
         originalNameTop: nameBounds.top,
         originalNameLeft: nameBounds.left,
         scrollTo: nameParentBounds.bottom - nameBounds.height - 5
@@ -76,31 +86,35 @@ class Sequence extends Component {
     if (this.state.scrollTo > signalEl.scrollTop) {
       change = {
         type: 'moving',
-        containerStyle: null,
-        nameStyle: {
+        containerStyle: Object.assign({}, this.baseContainerStyle),
+        nameStyle: Object.assign({}, this.baseNameStyle, {
           position: 'fixed',
           left: (this.state.originalNameLeft + this.signalLeft) + 'px',
           top: '122px'
-        }
+        })
       }
     }
 
     if (signalEl.scrollTop > this.state.scrollTo) {
       change = {
         type: 'bottom',
-        containerStyle: {
+        containerStyle: Object.assign({}, this.baseContainerStyle, {
           position: 'relative'
-        },
-        nameStyle: {
+        }),
+        nameStyle: Object.assign({}, this.baseNameStyle, {
           position: 'absolute',
-          left: '10px',
+          left: this.props.sequence.name ? '10px' : '5px',
           bottom: '5px'
-        }
+        })
       }
     }
 
     if (this.state.originalNameTop > signalEl.scrollTop) {
-      change = {type: 'default', containerStyle: null, nameStyle: null}
+      change = {
+        type: 'default',
+        containerStyle: Object.assign({}, this.baseContainerStyle),
+        nameStyle: Object.assign({}, this.baseNameStyle)
+      }
     }
 
     if (this.state.type !== change.type) {

--- a/src/components/Debugger/Signals/Signal/Sequence/index.js
+++ b/src/components/Debugger/Signals/Signal/Sequence/index.js
@@ -117,7 +117,6 @@ class Sequence extends Component {
     }
   }
   render () {
-
     // Alter style based on sequence name
     const containerStyle = Object.assign({}, this.state.containerStyle)
     if (this.props.sequence.name) {
@@ -126,8 +125,7 @@ class Sequence extends Component {
         backgroundColor: nameToColors(this.props.sequence.name, this.props.sequence.name, 0.9, 0.2).backgroundColor,
         color: nameToColors(this.props.sequence.name, this.props.sequence.name).backgroundColor
       })
-    }
-    else {
+    } else {
       Object.assign(containerStyle, {
         flexBasis: '20px',
         backgroundColor: 'inherit',

--- a/src/components/Debugger/Signals/Signal/Sequence/index.js
+++ b/src/components/Debugger/Signals/Signal/Sequence/index.js
@@ -27,13 +27,7 @@ class Sequence extends Component {
     this.baseContainerStyle = {
       flexBasis: '20px'
     }
-    this.baseNameStyle = {}
-    if (this.props.sequence.name) {
-      this.baseContainerStyle.flexBasis = '30px'
-      this.baseContainerStyle.backgroundColor = nameToColors(this.props.sequence.name, this.props.sequence.name, 0.9, 0.2).backgroundColor
-      this.baseContainerStyle.color = nameToColors(this.props.sequence.name, this.props.sequence.name).backgroundColor
-    }
-    this.state = { containerStyle: this.baseContainerStyle, nameStyle: this.baseNameStyle }
+    this.state = { containerStyle: this.baseContainerStyle, nameStyle: {} }
   }
   componentDidMount () {
     const signalEl = document.querySelector('#signal')
@@ -65,18 +59,18 @@ class Sequence extends Component {
     let change = {
       type: 'default',
       containerStyle: Object.assign({}, this.baseContainerStyle),
-      nameStyle: Object.assign({}, this.baseNameStyle)
+      nameStyle: {}
     }
 
     if (nameBounds.top < signalEl.scrollTop) {
       change = {
         type: 'initialMoving',
         containerStyle: Object.assign({}, this.baseContainerStyle),
-        nameStyle: Object.assign({}, this.baseNameStyle, {
+        nameStyle: {
           position: 'fixed',
           left: (nameBounds.left + this.signalLeft) + 'px',
           top: '122px'
-        }),
+        },
         originalNameTop: nameBounds.top,
         originalNameLeft: nameBounds.left,
         scrollTo: nameParentBounds.bottom - nameBounds.height - 5
@@ -87,11 +81,11 @@ class Sequence extends Component {
       change = {
         type: 'moving',
         containerStyle: Object.assign({}, this.baseContainerStyle),
-        nameStyle: Object.assign({}, this.baseNameStyle, {
+        nameStyle: {
           position: 'fixed',
           left: (this.state.originalNameLeft + this.signalLeft) + 'px',
           top: '122px'
-        })
+        }
       }
     }
 
@@ -101,11 +95,12 @@ class Sequence extends Component {
         containerStyle: Object.assign({}, this.baseContainerStyle, {
           position: 'relative'
         }),
-        nameStyle: Object.assign({}, this.baseNameStyle, {
+        nameStyle: {
           position: 'absolute',
+          // If sequence has name, adjust for thicker width
           left: this.props.sequence.name ? '10px' : '5px',
           bottom: '5px'
-        })
+        }
       }
     }
 
@@ -113,7 +108,7 @@ class Sequence extends Component {
       change = {
         type: 'default',
         containerStyle: Object.assign({}, this.baseContainerStyle),
-        nameStyle: Object.assign({}, this.baseNameStyle)
+        nameStyle: {}
       }
     }
 
@@ -122,9 +117,27 @@ class Sequence extends Component {
     }
   }
   render () {
+
+    // Alter style based on sequence name
+    const containerStyle = Object.assign({}, this.state.containerStyle)
+    if (this.props.sequence.name) {
+      Object.assign(containerStyle, {
+        flexBasis: '30px',
+        backgroundColor: nameToColors(this.props.sequence.name, this.props.sequence.name, 0.9, 0.2).backgroundColor,
+        color: nameToColors(this.props.sequence.name, this.props.sequence.name).backgroundColor
+      })
+    }
+    else {
+      Object.assign(containerStyle, {
+        flexBasis: '20px',
+        backgroundColor: 'inherit',
+        color: '#999'
+      })
+    }
+
     return (
       <div className='signal-sequence' onClick={(event) => event.stopPropagation()}>
-        <div style={this.state.containerStyle} className='signal-sequenceNameContainer'>
+        <div style={containerStyle} className='signal-sequenceNameContainer'>
           <div
             ref={(node) => { this.name = node }}
             className='signal-sequenceName'

--- a/src/components/Debugger/Signals/Signal/Sequence/styles.css
+++ b/src/components/Debugger/Signals/Signal/Sequence/styles.css
@@ -11,7 +11,6 @@
 
 .signal-sequenceNameContainer {
   flex: 0 0;
-  color: #999;
   text-align: center;
   border-right: 1px solid #F0F0F0;
 }

--- a/src/components/Debugger/Signals/Signal/Sequence/styles.css
+++ b/src/components/Debugger/Signals/Signal/Sequence/styles.css
@@ -10,7 +10,8 @@
 }
 
 .signal-sequenceNameContainer {
-  flex: 0 0 30px;
+  flex: 0 0;
+  color: #999;
   text-align: center;
   border-right: 1px solid #F0F0F0;
 }
@@ -19,7 +20,7 @@
   position: relative;
   display: inline-block;
   font-size: 10px;
-  color: #999;
+  color: 'inherit';
   writing-mode: vertical-rl;
   letter-spacing: 0.25em;
   text-indent: 5px;


### PR DESCRIPTION
Make named sequences colored in the signals view. This makes it easier to identify the important sequences apart from all the normal sequences that is created as part of factories/operators etc.

To make some nicer colors, I've used `color-hash` library, as I found the built-in color generator's colors a bit too hard on the eyes. This also will change the colors of the signals list slightly. Let me know if this is an issue.

@christianalfoni 