### PR TITLE
Make Show actions in signals view act like Show props

### DIFF
--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -111,11 +111,11 @@ export function updateActionError ({props, state}) {
   state.set(`${signalPath}.functionsRun.${execution.functionIndex}.error`, execution.error)
 }
 
-export function toggleActions ({ props, state }) {
+export function showHideAllActions ({props, state}) {
+  const showActions = state.get('storage.showActions')
   const signalsKey = state.get(`signals.${props.executionId}`) ? 'signals' : 'executedBySignals'
-  const expandedActions = state.get(`${signalsKey}.${props.executionId}.expandedActions`)
 
-  if (Object.keys(expandedActions).length) {
+  if (!showActions) {
     state.set(`${signalsKey}.${props.executionId}.expandedActions`, {})
   } else {
     const functionsRun = state.get(`${signalsKey}.${props.executionId}.functionsRun`)

--- a/src/app/actions.js
+++ b/src/app/actions.js
@@ -113,14 +113,16 @@ export function updateActionError ({props, state}) {
 
 export function showHideAllActions ({props, state}) {
   const showActions = state.get('storage.showActions')
-  const signalsKey = state.get(`signals.${props.executionId}`) ? 'signals' : 'executedBySignals'
+
+  const currentSignalExecutionId = state.get('currentSignalExecutionId')
+  const signalsKey = state.get(`signals.${currentSignalExecutionId}`) ? 'signals' : 'executedBySignals'
 
   if (!showActions) {
-    state.set(`${signalsKey}.${props.executionId}.expandedActions`, {})
+    state.set(`${signalsKey}.${currentSignalExecutionId}.expandedActions`, {})
   } else {
-    const functionsRun = state.get(`${signalsKey}.${props.executionId}.functionsRun`)
+    const functionsRun = state.get(`${signalsKey}.${currentSignalExecutionId}.functionsRun`)
     Object.keys(functionsRun).forEach((key) => {
-      state.set(`${signalsKey}.${props.executionId}.expandedActions.${key}`, true)
+      state.set(`${signalsKey}.${currentSignalExecutionId}.expandedActions.${key}`, true)
     })
   }
 }

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -50,7 +50,7 @@ export default (config) => Module({
     toggleFullPathNamesClicked: sequences.toggleFullPathName,
     actionToggled: sequences.toggleAction,
     propsToggled: sequences.toggleProps,
-    actionsToggled: sequences.toggleActions,
+    showActionsToggled: sequences.toggleShowActions,
     showPropsToggled: sequences.toggleShowProps,
     createSignalTestClicked: sequences.createSignalTest
   }

--- a/src/app/modules/storage/index.js
+++ b/src/app/modules/storage/index.js
@@ -35,7 +35,8 @@ export default Module(({ controller }) => {
   return {
     state: {
       showFullPathNames: false,
-      showProps: true
+      showProps: true,
+      showActions: false
     },
     signals: {
       initialized: sequences.initialize

--- a/src/app/sequences.js
+++ b/src/app/sequences.js
@@ -2,8 +2,6 @@ import {set, toggle, equals, wait} from 'cerebral/operators'
 import {state, props} from 'cerebral/tags'
 import * as actions from './actions'
 
-export const toggleActions = actions.toggleActions
-
 export const toggleAction = actions.toggleAction
 
 export const setError = set(state`error`, props`error`)
@@ -53,11 +51,18 @@ export const reset = actions.reset
 
 export const changeSearchValue = set(state`searchValue`, props`value`)
 
+export const toggleShowActions = [
+  toggle(state`storage.showActions`),
+  actions.showHideAllActions,
+  actions.storeOptions
+]
+
 export const toggleShowProps = [toggle(state`storage.showProps`), actions.storeOptions]
 
 export const setSignal = [
   set(state`currentPage`, 'signals'),
-  actions.setCurrentExecutionId
+  actions.setCurrentExecutionId,
+  actions.showHideAllActions
 ]
 
 export const toggleFullPathName = [

--- a/src/app/sequences.js
+++ b/src/app/sequences.js
@@ -35,7 +35,7 @@ export const handlePayload = [
     init: [actions.clean, actions.setInitialPayload],
     bulk: [actions.clean, actions.parseAndRunMessages],
     executionStart: actions.addSignal,
-    execution: [actions.updateSignal, actions.runMutation],
+    execution: [actions.updateSignal, actions.runMutation, actions.showHideAllActions],
     executionFunctionEnd: actions.updateActionOutput,
     executionPathStart: actions.updateSignalPath,
     executionEnd: actions.endSignalExecution,

--- a/src/components/Debugger/Signals/Signal/index.js
+++ b/src/components/Debugger/Signals/Signal/index.js
@@ -16,9 +16,10 @@ export default connect({
   signal: state`signals.${state`currentSignalExecutionId`}`,
   executedBySignals: state`executedBySignals`,
   showProps: state`storage.showProps`,
+  showActions: state`storage.showActions`,
   searchValue: state`searchValue`,
   showPropsToggled: signal`showPropsToggled`,
-  actionsToggled: signal`actionsToggled`,
+  showActionsToggled: signal`showActionsToggled`,
   actionToggled: signal`actionToggled`,
   propsToggled: signal`propsToggled`,
   mutationClicked: signal`mutationClicked`,
@@ -125,7 +126,7 @@ export default connect({
                 signal={executedBySignal}
                 pathClicked={this.props.pathClicked}
                 showPropsToggled={this.props.showPropsToggled}
-                actionsToggled={this.props.actionsToggled}
+                showActionsToggled={this.props.showActionsToggled}
                 actionToggled={this.props.actionToggled}
                 propsToggled={this.props.propsToggled}
                 showProps={this.props.showProps}
@@ -156,9 +157,7 @@ export default connect({
           }}>
             {this.props.signal.name}
             <div className='signal-settingsContainer'>
-              <button onClick={() => this.props.actionsToggled({ executionId: this.props.signal.executionId })}>
-                {Object.keys(this.props.signal.expandedActions).length ? 'Collapse actions' : 'Expand actions'}
-              </button>
+              <label>actions: <input type='checkbox' onChange={() => this.props.showActionsToggled({ executionId: this.props.signal.executionId })} checked={this.props.showActions} /></label>
               {this.props.executedBy ? null : <label>props: <input type='checkbox' onChange={() => this.props.showPropsToggled()} checked={this.props.showProps} /></label>}
             </div>
           </h3>


### PR DESCRIPTION
Instead of being signal-specific, the actions checkbox now acts globally. Rationale is that when debugging you often want the actions to stay either expanded or collapsed during several signal executions. It also makes the interface more consistent.