### PR TITLE
Proposed discussion: Renames project to Cerebra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
-# Cerebral-Debugger
+# Cerebra
 
 [![Build status][travis-image]][travis-url]
 [![Build status](https://ci.appveyor.com/api/projects/status/oxof3l7jq59ovaof?svg=true)](https://ci.appveyor.com/project/reflog/cerebral-debugger)
 
-The powerful development tool for [Cerebral](http://cerebraljs.com).
+Cerebra is the most powerful mutant detecting system currently available (for [Cerebral](http://cerebraljs.com)).
 
 The docs you can find at the [Cerebral website](http://cerebraljs.com/docs/introduction/debugger.html).
+
+---
+
+## Why the Cerebra name?
+
+Cerebral is all about side effect management. A common side effect in JavaScript is mutation. This debugger helps you track these side effects and mutations. Another great tool for tracking mutations is [Charles Xaviers Cerebra located in the heart of Xavier's School For Higher Learning](<http://marvel.wikia.com/wiki/Cerebra_(Mutant_Detector)>). Now you can have your own Cerebra to help those mutants find their way in life.
 
 [travis-image]: https://img.shields.io/travis/cerebral/cerebral-debugger.svg?style=flat
 [travis-url]: https://travis-ci.org/cerebral/cerebral-debugger

--- a/electron/index.html
+++ b/electron/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>Cerebral Debugger</title>
+    <title>Cerebra: The Cerebral Debugger</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
       html, body {

--- a/electron/main.js
+++ b/electron/main.js
@@ -66,7 +66,7 @@ function createWindow () {
     {
       label: 'Application',
       submenu: [
-        { label: 'Cerebral Debugger v' + appVersion },
+        { label: 'Cerebra: The Cerebral Debugger v' + appVersion },
         { type: 'separator' },
         {
           label: 'Learn More',

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cerebral-debugger",
+  "name": "cerebra",
   "version": "2.0.0",
   "private": true,
   "main": "main.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cerebral-debugger",
+  "name": "cerebra",
   "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "cerebral-debugger",
+  "name": "cerebra",
   "version": "2.3.0",
-  "description": "Cerebral Debugger",
+  "description": "Cerebra: The Cerebral Debugger",
   "private": true,
   "main": "electron/main.js",
   "scripts": {
@@ -25,7 +25,7 @@
   "homepage": "http://cerebraljs.com/docs/introduction/debugger.html",
   "author": "Christian Alfoni <christianalfoni@gmail.com>",
   "build": {
-    "productName": "Cerebral Debugger",
+    "productName": "Cerebra: Cerebral Debugger",
     "appId": "cerebral.debugger",
     "win": {
       "target": [


### PR DESCRIPTION
This is a _very important_ PR: Starting the discussion to rename the cerebral debugger to Cerebra! Why? As summerized in the README:

> Cerebral is all about side effect management. A common side effect in JavaScript is mutation. This debugger helps you track these side effects and mutations. Another great tool for tracking mutations is [Charles Xaviers Cerebra located in the heart of Xavier's School For Higher Learning](<http://marvel.wikia.com/wiki/Cerebra_(Mutant_Detector)>). Now you can have your own Cerebra to help those mutants find their way in life.

Or in the new tagline:

> Cerebra is the most powerful mutant detecting system currently available (_for [Cerebral](http://cerebraljs.com)_).

I think its a great fit as the "newest" mutant tracking device in Marvel (current version) is called Cerebra which also is a subset of **Cerebra**l. Read more about cerebra here: http://marvel.wikia.com/wiki/Cerebra_(Mutant_Detector). I don't know how much into the comics we should dive here, because as it is with the multiverses of Marvel thing changes, and I think currently the cerebra isn't used for tracking mutants, but reading mutant memories, but traditionally it was used to enhance telepathic abilities helping Professor X amplify his power to help mutants etc. I think it's fine using the traditional use case for cerebra, for the joke of it.

I don't know what you would want to change and where else to change the name for this to be complete. As of now I've pretty much just done a search and replace. Another thing I'd like to see is a specific version of the Cerebral logo with the "cerebra helmet".  