### PR TITLE
Fix debugger crash when signal.staticTree is undefined - Fixes #63

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -2,6 +2,11 @@ import ColorHash from 'color-hash'
 import traverse from 'traverse'
 
 export function getActionNameByIndex(signal, functionIndex) {
+  // Guard against undefined signal, staticTree, or items
+  if (!signal || !signal.staticTree || !signal.staticTree.items) {
+    return null
+  }
+  
   return traverse(signal.staticTree.items).reduce((acc, item) => {
     if (item && item.functionIndex === functionIndex) {
       return item.name


### PR DESCRIPTION
This PR addresses the crash issue mentioned in #63.

## Problem
The debugger often crashes with the error: `TypeError: Cannot read property 'items' of undefined` when `signal.staticTree` is undefined or null.

## Solution
- Added null/undefined guards to the `getActionNameByIndex` function in `src/common/utils.js`
- The function now returns `null` gracefully instead of throwing an error
- Handles cases where `signal`, `signal.staticTree`, or `signal.staticTree.items` are undefined

## Changes
- Enhanced error handling in `getActionNameByIndex` function
- Added comprehensive guard clauses to prevent crashes
- Maintains backward compatibility - existing functionality unchanged when data is valid

## Testing
The fix has been tested to ensure it handles all edge cases:
- ✅ `undefined` signal
- ✅ `signal` with `undefined` staticTree  
- ✅ `signal.staticTree` with `undefined` items
- ✅ Valid signal structure works as before

Fixes #63