### PR TITLE
Fix debugger crash when signal.staticTree is undefined - Closes cereb…

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -2,6 +2,9 @@ import ColorHash from 'color-hash'
 import traverse from 'traverse'
 
 export function getActionNameByIndex(signal, functionIndex) {
+  if (!signal || !signal.staticTree || !signal.staticTree.items) {
+    return null
+  }
   return traverse(signal.staticTree.items).reduce((acc, item) => {
     if (item && item.functionIndex === functionIndex) {
       return item.name


### PR DESCRIPTION
The debugger crashes with `Cannot read property 'items' of undefined` when signal.staticTree is undefined or null.

Added null/undefined guards to the `getActionNameByIndex` function in `src/common/utils.js` to return null gracefully instead of throwing an error.

Closes #63